### PR TITLE
Disable smooth scrolling defaults of bootstrap

### DIFF
--- a/internal/app/ui/templates/layouts/head.html
+++ b/internal/app/ui/templates/layouts/head.html
@@ -37,6 +37,11 @@
 	.hljs-ln td.hljs-ln-code {
 		padding-left: 0.25em;
 	}
+
+	/* (#64) Disable here until we compile our own bootstrap CSS */
+	:root {
+		scroll-behavior: auto;
+	}
 </style>
 {{ define "head_scripts" }}{{ end }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.1.1/marked.min.js" integrity="sha512-+mCmSlBpa1bF0npQzdpxFWIyJaFbVdEcuyET6FtmHmlXIacQjN/vQs1paCsMlVHHZ2ltD2VTHy3fLFhXQu0AMA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
Resolves #64 

This is only temporary until we start bundling our own bootstrap CSS where we can disable this functionality using an SCSS variable (https://getbootstrap.com/docs/5.2/customize/options/)