### PR TITLE
Display last chef run timestamp in node header

### DIFF
--- a/internal/app/ui/templates/layouts/head.html
+++ b/internal/app/ui/templates/layouts/head.html
@@ -51,5 +51,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.1.1/marked.min.js" integrity="sha512-+mCmSlBpa1bF0npQzdpxFWIyJaFbVdEcuyET6FtmHmlXIacQjN/vQs1paCsMlVHHZ2ltD2VTHy3fLFhXQu0AMA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.0/purify.min.js" integrity="sha512-/hVAZO5POxCKdZMSLefw30xEVwjm94PAV9ynjskGbIpBvHO9EBplEcdUlBdCKutpZsF+La8Ag4gNrG0gAOn3Ig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.7/dayjs.min.js" integrity="sha512-hcV6DX35BKgiTiWYrJgPbu3FxS6CsCjKgmrsPRpUPkXWbvPiKxvSVSdhWX0yXcPctOI2FJ4WP6N1zH+17B/sAA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.7/plugin/relativeTime.min.js" integrity="sha512-MVzDPmm7QZ8PhEiqJXKz/zw2HJuv61waxb8XXuZMMs9b+an3LoqOqhOEt5Nq3LY1e4Ipbbd/e+AWgERdHlVgaA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.8.0/highlightjs-line-numbers.min.js"></script>

--- a/internal/app/ui/templates/layouts/head.html
+++ b/internal/app/ui/templates/layouts/head.html
@@ -9,6 +9,10 @@
 		font-weight: bold;
 	}
 
+	.node-headline small {
+		font-weight: normal;
+	}
+
 	main a {
 		text-decoration: none;
 	}
@@ -46,5 +50,6 @@
 {{ define "head_scripts" }}{{ end }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.1.1/marked.min.js" integrity="sha512-+mCmSlBpa1bF0npQzdpxFWIyJaFbVdEcuyET6FtmHmlXIacQjN/vQs1paCsMlVHHZ2ltD2VTHy3fLFhXQu0AMA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.0/purify.min.js" integrity="sha512-/hVAZO5POxCKdZMSLefw30xEVwjm94PAV9ynjskGbIpBvHO9EBplEcdUlBdCKutpZsF+La8Ag4gNrG0gAOn3Ig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.7/dayjs.min.js" integrity="sha512-hcV6DX35BKgiTiWYrJgPbu3FxS6CsCjKgmrsPRpUPkXWbvPiKxvSVSdhWX0yXcPctOI2FJ4WP6N1zH+17B/sAA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.8.0/highlightjs-line-numbers.min.js"></script>

--- a/internal/app/ui/templates/partials/node/header.html
+++ b/internal/app/ui/templates/partials/node/header.html
@@ -1,10 +1,47 @@
 <div class="d-flex">
 	<h2 class="node-headline flex-grow-1">{{ .node.Name }}
-		{{ if index .node.AutomaticAttributes "$.IPAddress" }}
-		<small class="text-muted">({{ index .node.AutomaticAttributes "$.IPAddress" }})</small>
+		{{ if index .node.AutomaticAttributes "$.ipaddress" }}
+		<small class="text-muted">({{ index .node.AutomaticAttributes "$.ipaddress" }})</small>
 		{{ end }}
 	</h2>
 	<div class="node-highlights">
+		<!-- badges will go here eventually (#74) -->
+	</div>
+</div>
+
+<hr>
+<div class="node-details d-flex">
+	<ul class="list-unstyled flex-grow-1">
+		{{ if .node.PolicyName }}
+		<li>
+			<strong>Policy:</strong>
+			<a href="/ui/policies/{{ .node.PolicyName }}">{{ .node.PolicyName }}</a>
+		</li>
+		<li>
+			<strong>Policy Group:</strong>
+			<a href="/ui/policy-groups/{{ .node.PolicyGroup }}">{{ .node.PolicyGroup }}</a>
+		</li>
+		{{ else }}
+		<li>
+			<strong>Environment:</strong>
+			<a href="/ui/environments/{{ .node.Environment}}">{{ .node.Environment}}</a>
+		</li>
+		{{ end }}
+		<li><strong>Run List:</strong>
+			<ul class="list-inline">
+				{{ range .node.RunList }}
+				<li class="list-inline-item"><a href="/ui/{{ makeRunListURL . }}">{{.}}</a></li>
+				{{end}}
+			</ul>
+		</li>
+	</ul>
+	<div class="node-highlights text-end">
+		{{ if index .node.AutomaticAttributes "$.os_release.pretty_name" }}
+		<div><span class="text-muted">OS:</span> <span>{{ index .node.AutomaticAttributes "$.os_release.pretty_name" }}</span></div>
+		{{ end }}
+		{{ if index .node.AutomaticAttributes "$.chef_packages.chef.version" }}
+		<div><span class="text-muted">Chef version:</span> <span>{{ index .node.AutomaticAttributes "$.chef_packages.chef.version" }}</span></div>
+		{{ end }}
 		{{ if index .node.AutomaticAttributes "$.ohai_time" }}
 		<div><span class="text-muted">Last chef run:</span> <span id="last-run-timestamp"></span></div>
 		<script>
@@ -16,28 +53,3 @@
 	</div>
 </div>
 
-<hr>
-<ul class="list-unstyled">
-    {{ if .node.PolicyName }}
-		<li>
-			<strong>Policy:</strong>
-			<a href="/ui/policies/{{ .node.PolicyName }}">{{ .node.PolicyName }}</a>
-		</li>
-		<li>
-			<strong>Policy Group:</strong>
-			<a href="/ui/policy-groups/{{ .node.PolicyGroup }}">{{ .node.PolicyGroup }}</a>
-		</li>
-    {{ else }}
-		<li>
-			<strong>Environment:</strong>
-			<a href="/ui/environments/{{ .node.Environment}}">{{ .node.Environment}}</a>
-		</li>
-    {{ end }}
-	<li><strong>Run List:</strong>
-		<ul class="list-inline">
-            {{ range .node.RunList }}
-				<li class="list-inline-item"><a href="/ui/{{ makeRunListURL . }}">{{.}}</a></li>
-            {{end}}
-		</ul>
-	</li>
-</ul>

--- a/internal/app/ui/templates/partials/node/header.html
+++ b/internal/app/ui/templates/partials/node/header.html
@@ -36,8 +36,8 @@
 		</li>
 	</ul>
 	<div class="node-highlights text-end">
-		{{ if index .node.AutomaticAttributes "$.os_release.pretty_name" }}
-		<div><span class="text-muted">OS:</span> <span>{{ index .node.AutomaticAttributes "$.os_release.pretty_name" }}</span></div>
+		{{ if index .node.AutomaticAttributes "$.lsb.description" }}
+		<div><span class="text-muted">OS:</span> <span>{{ index .node.AutomaticAttributes "$.lsb.description" }}</span></div>
 		{{ end }}
 		{{ if index .node.AutomaticAttributes "$.chef_packages.chef.version" }}
 		<div><span class="text-muted">Chef version:</span> <span>{{ index .node.AutomaticAttributes "$.chef_packages.chef.version" }}</span></div>

--- a/internal/app/ui/templates/partials/node/header.html
+++ b/internal/app/ui/templates/partials/node/header.html
@@ -1,5 +1,5 @@
 <div class="d-flex">
-	<h2 class="node-headline flex-grow-1">{{ .node.Name }}
+	<h2 class="node-headline flex-grow-1 mb-0">{{ .node.Name }}
 		{{ if index .node.AutomaticAttributes "$.ipaddress" }}
 		<small class="text-muted">({{ index .node.AutomaticAttributes "$.ipaddress" }})</small>
 		{{ end }}
@@ -45,9 +45,12 @@
 		{{ if index .node.AutomaticAttributes "$.ohai_time" }}
 		<div><span class="text-muted">Last chef run:</span> <span id="last-run-timestamp"></span></div>
 		<script>
-			ohaiTime = '{{ index .node.AutomaticAttributes "$.ohai_time" }}'
-			lastRun = dayjs.unix(ohaiTime).format('YYYY-MM-DD HH:mm:ss')
-			document.getElementById('last-run-timestamp').innerText = lastRun
+			dayjs.extend(window.dayjs_plugin_relativeTime)
+			let el = document.getElementById('last-run-timestamp')
+			let ohaiTime = '{{ index .node.AutomaticAttributes "$.ohai_time" }}'
+			let lastRun = dayjs.unix(ohaiTime)
+			el.innerText = dayjs().to(lastRun)
+			el.title = lastRun
 		</script>
 		{{ end }}
 	</div>

--- a/internal/app/ui/templates/partials/node/header.html
+++ b/internal/app/ui/templates/partials/node/header.html
@@ -1,5 +1,21 @@
-<h2 class="node-headline">{{ .node.Name}}</h2>
-<p class="lead">{{ .node.DefaultAttributes.ipaddress }}</p>
+<div class="d-flex">
+	<h2 class="node-headline flex-grow-1">{{ .node.Name }}
+		{{ if index .node.AutomaticAttributes "$.IPAddress" }}
+		<small class="text-muted">({{ index .node.AutomaticAttributes "$.IPAddress" }})</small>
+		{{ end }}
+	</h2>
+	<div class="node-highlights">
+		{{ if index .node.AutomaticAttributes "$.ohai_time" }}
+		<div><span class="text-muted">Last chef run:</span> <span id="last-run-timestamp"></span></div>
+		<script>
+			ohaiTime = '{{ index .node.AutomaticAttributes "$.ohai_time" }}'
+			lastRun = dayjs.unix(ohaiTime).format('YYYY-MM-DD HH:mm:ss')
+			document.getElementById('last-run-timestamp').innerText = lastRun
+		</script>
+		{{ end }}
+	</div>
+</div>
+
 <hr>
 <ul class="list-unstyled">
     {{ if .node.PolicyName }}


### PR DESCRIPTION
Closes #76 

To investigate before merging:
- `ohai_time` format on other platforms, e.g. windows.
- Display as relative time

