### PR TITLE
only run goreleaser on tags and pushes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: release
 
 on:
-  pull_request:
   push:
     branches:
       - 'main'


### PR DESCRIPTION
The `go-test` workflow builds the project so we should catch failures there.

This lets us keep the dockerhub secret vars out of pull request runs and also saves some needless building