### PR TITLE
Create and use dedicated non-privileged docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM alpine:3.16 as alpine
-RUN apk add --update --no-cache ca-certificates
+ARG USERNAME=chefbrowser
+ARG UID=1001
+ARG GID=1001
+
+FROM alpine:3.17 as alpine
+ARG USERNAME
+ARG UID
+ARG GID
+RUN apk add --update --no-cache ca-certificates shadow && \
+    addgroup -g ${GID} ${USERNAME} && \
+    adduser -u ${UID} -G ${USERNAME} --disabled-password --system ${USERNAME}
 
 FROM scratch
+ARG USERNAME
+ARG UID
+ARG GID
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=alpine /etc/passwd /etc/passwd
 COPY chefbrowser /go/bin/chefbrowser
-USER nobody
-ENV GIN_MODE=release
+USER ${UID}:${GID}
 EXPOSE 8080
 ENTRYPOINT ["/go/bin/chefbrowser"]


### PR DESCRIPTION
The `nobody` user has a known UID and is susceptible to its own security problems and is therefore not recommended. This creates a dedicated user for the purpose of running chefbrowser.