### PR TITLE
Enable dependabot scanning for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     directory: "/ui"
     schedule:
       interval: "daily"
-  - package-ecosystem: github-actions
+  - package-ecosystem: "github-actions"
     directory: "/"
     labels:
       - "github_actions"
@@ -20,3 +20,7 @@ updates:
       - "pr/no-changelog"
     schedule:
       interval: daily
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
So we can keep all build resources up to date :) 