### PR TITLE
ignore local node_modules dir in UI build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ dist/*
 *.iml
 !defaults.ini
 *.ini
+ui/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ dist/*
 !defaults.ini
 *.ini
 ui/node_modules/
+bin/
+dist/
+.github/


### PR DESCRIPTION
Docker is not ignoring the local `ui/node_modules` directory when copying files over to build. This is unnecessary and will cause build errors if the versions differ