### PR TITLE
Ignore reformatting commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformatted entire project with .editorconfig
+ac9c06a796083df7dbc918b1b14b78213287e2b8


### PR DESCRIPTION
In #273 we changed nearly every file so that it abides by the style config in .editorconfig. This unfortunately makes a mess of the git blame view so we can work around that using this file