### PR TITLE
Prevent unformatted logging messages

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -59,7 +59,6 @@ func New(cfg *config.Config) {
 			LogHost:         true,
 			LogMethod:       true,
 			LogURI:          true,
-			LogRequestID:    true,
 			LogUserAgent:    true,
 			LogStatus:       true,
 			LogResponseSize: true,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,14 +52,38 @@ func New(cfg *config.Config) {
 
 	if cfg.Logging.RequestLogging {
 		logger.Debug("request logging is enabled")
-		logCfg := middleware.DefaultLoggerConfig
+		// DH: We might want to make these fields user configurable at some point
+		logCfg := middleware.RequestLoggerConfig{
+			LogLatency:      true,
+			LogRemoteIP:     true,
+			LogHost:         true,
+			LogMethod:       true,
+			LogURI:          true,
+			LogRequestID:    true,
+			LogUserAgent:    true,
+			LogStatus:       true,
+			LogResponseSize: true,
+			LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+				logger.Info("request",
+					zap.String("remote_ip", v.RemoteIP),
+					zap.String("host", v.Host),
+					zap.String("method", v.Method),
+					zap.String("uri", v.URI),
+					zap.Int("status", v.Status),
+					zap.Int64("latency_ms", v.Latency.Milliseconds()),
+					zap.Int64("response_bytes", v.ResponseSize),
+					zap.String("user_agent", v.UserAgent),
+				)
+				return nil
+			},
+		}
 		if !cfg.Logging.LogHealthChecks {
 			logger.Debug("log_health_checks = false; requests to health check endpoint will not be logged")
 			logCfg.Skipper = func(c echo.Context) bool {
 				return c.Path() == cfg.Server.BasePath+"/api/health"
 			}
 		}
-		engine.Use(middleware.LoggerWithConfig(logCfg))
+		engine.Use(middleware.RequestLoggerWithConfig(logCfg))
 	}
 
 	if cfg.Server.EnableGzip {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,6 +36,7 @@ func New(cfg *config.Config) {
 
 	engine := echo.New()
 	engine.HideBanner = true
+	engine.HidePort = true
 
 	if cfg.App.AppMode == "development" {
 		engine.Debug = true


### PR DESCRIPTION
- Disables the unformatted `⇨ https server started on 0.0.0.0:8080` message
- Switch to modern middleware for request logging (https://echo.labstack.com/docs/middleware/logger#new-requestlogger-middleware)

## Breaking log format changes

Some request log fields have been renamed, changed, or removed.

### Added fields

- `level` added (always `info`)
- `msg` added (always `request`)
- `ts` (ISO8601 format) as replacement for `time` (to match application logs)
- `latency_ms` (millisecond unit) as replacement for `latency` and `latency_human`
- `response_bytes` as replacement for `bytes_out`

### Removed fields

- `time` (replaced by `ts`)
- `id`
- `latency`
- `latency_human`
- `error`
- `bytes_in`
- `bytes_out`

Closes #279 