### PR TITLE
UI improvements and mock data for development.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,21 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "path to config file")
+	rootCmd.PersistentFlags().String("listen-addr", "", "address to listen on (default: 0.0.0.0:8080)")
+	rootCmd.PersistentFlags().String("app-mode", "", "application mode: production or development")
+	rootCmd.PersistentFlags().Bool("use-mock-data", false, "use mock data instead of real Chef server")
+	rootCmd.PersistentFlags().String("chef-server-url", "", "Chef server URL")
+	rootCmd.PersistentFlags().String("chef-username", "", "Chef server username")
+	rootCmd.PersistentFlags().String("chef-key-file", "", "path to Chef client key file")
+	rootCmd.PersistentFlags().Bool("chef-ssl-verify", true, "verify Chef server SSL certificate")
+	rootCmd.PersistentFlags().String("log-level", "", "log level: debug, info, warning, error, fatal")
+	rootCmd.PersistentFlags().String("log-format", "", "log format: json or console")
+	rootCmd.PersistentFlags().String("log-output", "", "log output: stdout or file path")
+	rootCmd.PersistentFlags().Bool("request-logging", true, "enable request logging")
+	rootCmd.PersistentFlags().Bool("log-health-checks", true, "log health check requests")
+	rootCmd.PersistentFlags().String("base-path", "", "base path for reverse proxy")
+	rootCmd.PersistentFlags().String("trusted-proxies", "", "comma-separated trusted proxy CIDRs")
+	rootCmd.PersistentFlags().Bool("enable-gzip", false, "enable gzip compression")
 }
 
 // initConfig reads in config defaults, user config files, and ENV variables if set.
@@ -51,7 +66,22 @@ func initConfig() {
 	v.SetConfigName("chefbrowser")
 	v.AddConfigPath("/etc/chefbrowser/")
 
-	// load defaults
+	v.BindPFlag("default.listen_addr", rootCmd.PersistentFlags().Lookup("listen-addr"))
+	v.BindPFlag("default.app_mode", rootCmd.PersistentFlags().Lookup("app-mode"))
+	v.BindPFlag("default.use_mock_data", rootCmd.PersistentFlags().Lookup("use-mock-data"))
+	v.BindPFlag("chef.server_url", rootCmd.PersistentFlags().Lookup("chef-server-url"))
+	v.BindPFlag("chef.username", rootCmd.PersistentFlags().Lookup("chef-username"))
+	v.BindPFlag("chef.key_file", rootCmd.PersistentFlags().Lookup("chef-key-file"))
+	v.BindPFlag("chef.ssl_verify", rootCmd.PersistentFlags().Lookup("chef-ssl-verify"))
+	v.BindPFlag("logging.level", rootCmd.PersistentFlags().Lookup("log-level"))
+	v.BindPFlag("logging.format", rootCmd.PersistentFlags().Lookup("log-format"))
+	v.BindPFlag("logging.output", rootCmd.PersistentFlags().Lookup("log-output"))
+	v.BindPFlag("logging.request_logging", rootCmd.PersistentFlags().Lookup("request-logging"))
+	v.BindPFlag("logging.log_health_checks", rootCmd.PersistentFlags().Lookup("log-health-checks"))
+	v.BindPFlag("server.base_path", rootCmd.PersistentFlags().Lookup("base-path"))
+	v.BindPFlag("server.trusted_proxies", rootCmd.PersistentFlags().Lookup("trusted-proxies"))
+	v.BindPFlag("server.enable_gzip", rootCmd.PersistentFlags().Lookup("enable-gzip"))
+
 	err := v.ReadConfig(bytes.NewBuffer(config.DefaultConfig))
 	if err != nil {
 		fmt.Println("failed to read default config, err:", err)

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ package config
 var DefaultConfig = []byte(`
 app_mode = production
 listen_addr = 0.0.0.0:8080
+use_mock_data = false
 
 [chef]
 server_url = http://localhost/organizations/example/
@@ -32,8 +33,9 @@ type chefConfig struct {
 }
 
 type appConfig struct {
-	AppMode    string `mapstructure:"app_mode"`
-	ListenAddr string `mapstructure:"listen_addr"`
+	AppMode     string `mapstructure:"app_mode"`
+	ListenAddr  string `mapstructure:"listen_addr"`
+	UseMockData bool   `mapstructure:"use_mock_data"`
 }
 
 type loggingConfig struct {

--- a/defaults.ini
+++ b/defaults.ini
@@ -1,6 +1,9 @@
 listen_addr = 0.0.0.0:8080
 app_mode = production
 
+# Use mock data instead of connecting to a real Chef server (for development/testing)
+use_mock_data = false
+
 [chef]
 server_url = https://localhost/organizations/example/
 username = example

--- a/internal/app/api/api.go
+++ b/internal/app/api/api.go
@@ -15,11 +15,11 @@ var basePath = ""
 type Service struct {
 	log    *logging.Logger
 	config *config.Config
-	chef   *chef.Service
+	chef   chef.Interface
 	engine *echo.Echo
 }
 
-func New(config *config.Config, engine *echo.Echo, chef *chef.Service, logger *logging.Logger) *Service {
+func New(config *config.Config, engine *echo.Echo, chef chef.Interface, logger *logging.Logger) *Service {
 	s := Service{
 		config: config,
 		chef:   chef,

--- a/internal/app/api/cookbooks.go
+++ b/internal/app/api/cookbooks.go
@@ -41,16 +41,9 @@ func (s *Service) getCookbookVersion(c echo.Context) error {
 func (s *Service) getCookbookVersions(c echo.Context) error {
 	name := c.Param("name")
 
-	resp, err := s.chef.GetClient().Cookbooks.GetAvailableVersions(name, "0")
+	versions, err := s.chef.GetCookbookVersions(c.Request().Context(), name)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, ErrorResponse("failed to fetch cookbook versions"))
-	}
-
-	var versions []string
-	for _, i := range resp {
-		for _, j := range i.Versions {
-			versions = append(versions, j.Version)
-		}
 	}
 
 	return c.JSON(http.StatusOK, versions)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,7 +20,7 @@ import (
 
 type AppService struct {
 	Log        *logging.Logger
-	Chef       *chef.Service
+	Chef       chef.Interface
 	APIService *api.Service
 	UIService  *ui.Service
 }

--- a/internal/app/ui/routes.go
+++ b/internal/app/ui/routes.go
@@ -310,9 +310,20 @@ func (s *Service) getNodes(c echo.Context) error {
 	})
 }
 
+// escapeSolrSpecialChars escapes characters that have special meaning in Solr/Lucene query syntax
+func escapeSolrSpecialChars(s string) string {
+	specialChars := []string{"\\", "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "?", ":", "/"}
+	result := s
+	for _, char := range specialChars {
+		result = strings.ReplaceAll(result, char, "\\"+char)
+	}
+	return result
+}
+
 // fuzzifySearchStr mimics the fuzzy search functionality
 // provided by chef https://github.com/chef/chef/blob/main/lib/chef/search/query.rb#L109
 func fuzzifySearchStr(s string) string {
+	escaped := escapeSolrSpecialChars(s)
 	format := []string{
 		"tags:*%v*",
 		"roles:*%v*",
@@ -326,7 +337,7 @@ func fuzzifySearchStr(s string) string {
 		if i > 0 {
 			b.WriteString(" OR ")
 		}
-		b.WriteString(fmt.Sprintf(f, s))
+		b.WriteString(fmt.Sprintf(f, escaped))
 	}
 	return b.String()
 }

--- a/internal/chef/cookbooks.go
+++ b/internal/chef/cookbooks.go
@@ -138,6 +138,22 @@ func (s Service) GetCookbookVersion(ctx context.Context, name string, version st
 	return &Cookbook{cookbook}, nil
 }
 
+func (s Service) GetCookbookVersions(ctx context.Context, name string) ([]string, error) {
+	resp, err := s.client.Cookbooks.GetAvailableVersions(name, "0")
+	if err != nil {
+		return nil, err
+	}
+
+	var versions []string
+	for _, i := range resp {
+		for _, j := range i.Versions {
+			versions = append(versions, j.Version)
+		}
+	}
+
+	return versions, nil
+}
+
 func (s Cookbook) GetFile(ctx context.Context, client *http.Client, path string) (string, error) {
 	t := strings.SplitN(path, "/", 2)[0]
 	var loc []chef.CookbookItem

--- a/internal/chef/cookbooks_test.go
+++ b/internal/chef/cookbooks_test.go
@@ -1,0 +1,46 @@
+package chef
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReverseSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "basic reverse",
+			input:    []string{"1.0.0", "2.0.0", "3.0.0"},
+			expected: []string{"3.0.0", "2.0.0", "1.0.0"},
+		},
+		{
+			name:     "single element",
+			input:    []string{"1.0.0"},
+			expected: []string{"1.0.0"},
+		},
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "two elements",
+			input:    []string{"a", "b"},
+			expected: []string{"b", "a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := make([]string, len(tt.input))
+			copy(input, tt.input)
+			ReverseSlice(input)
+			if !reflect.DeepEqual(input, tt.expected) {
+				t.Errorf("ReverseSlice() = %v, want %v", input, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/chef/mock.go
+++ b/internal/chef/mock.go
@@ -81,8 +81,9 @@ func (m *MockService) generateNodes() {
 
 	for i := 0; i < 1500; i++ {
 		prefix := prefixes[rng.Intn(len(prefixes))]
-		domain := domains[rng.Intn(len(domains))]
-		env := environments[rng.Intn(len(environments))]
+		envIdx := rng.Intn(len(environments))
+		domain := domains[envIdx]
+		env := environments[envIdx]
 
 		ipOctet1 := []int{10, 172, 192}[rng.Intn(3)]
 		var ipOctet2 int

--- a/internal/chef/mock.go
+++ b/internal/chef/mock.go
@@ -1,0 +1,624 @@
+package chef
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/drewhammond/chefbrowser/internal/common/logging"
+	"github.com/go-chef/chef"
+)
+
+type MockService struct {
+	log          *logging.Logger
+	nodes        []mockNodeData
+	roles        map[string]*chef.Role
+	environments map[string]*chef.Environment
+	cookbooks    map[string][]string
+	databags     map[string][]string
+	policies     map[string][]string
+	policyGroups map[string]map[string]string
+	groups       map[string]chef.Group
+}
+
+type mockNodeData struct {
+	Name        string
+	IPAddress   string
+	Environment string
+	OhaiTime    float64
+	RunList     []string
+}
+
+func NewMockService(log *logging.Logger) *MockService {
+	m := &MockService{log: log}
+	m.generateMockData()
+	log.Info("Mock service initialized with sample data")
+	return m
+}
+
+func (m *MockService) generateMockData() {
+	m.generateNodes()
+	m.generateRoles()
+	m.generateEnvironments()
+	m.generateCookbooks()
+	m.generateDatabags()
+	m.generatePolicies()
+	m.generateGroups()
+}
+
+func (m *MockService) generateNodes() {
+	rng := rand.New(rand.NewSource(42))
+	now := time.Now()
+
+	prefixes := []string{"web", "app", "db", "cache", "worker", "api", "lb", "monitor", "queue", "search"}
+	domains := []string{"prod.example.com", "staging.example.com", "dev.example.com", "qa.example.com"}
+	environments := []string{"production", "staging", "development", "qa"}
+	roles := []string{"role[base]", "role[webserver]", "role[database]", "role[monitoring]", "role[loadbalancer]"}
+	recipes := []string{"recipe[apache2]", "recipe[nginx]", "recipe[mysql]", "recipe[postgresql]", "recipe[redis]", "recipe[nodejs]"}
+
+	m.nodes = make([]mockNodeData, 0, 1500)
+
+	for i := 0; i < 1500; i++ {
+		prefix := prefixes[rng.Intn(len(prefixes))]
+		domain := domains[rng.Intn(len(domains))]
+		env := environments[rng.Intn(len(environments))]
+
+		ipOctet1 := []int{10, 172, 192}[rng.Intn(3)]
+		var ipOctet2 int
+		if ipOctet1 == 172 {
+			ipOctet2 = 16 + rng.Intn(16)
+		} else if ipOctet1 == 192 {
+			ipOctet2 = 168
+		} else {
+			ipOctet2 = rng.Intn(256)
+		}
+
+		hoursAgo := rng.Intn(168)
+		ohaiTime := float64(now.Add(-time.Duration(hoursAgo) * time.Hour).Unix())
+
+		runListSize := 1 + rng.Intn(4)
+		runList := make([]string, 0, runListSize)
+		runList = append(runList, roles[rng.Intn(len(roles))])
+		for j := 1; j < runListSize; j++ {
+			runList = append(runList, recipes[rng.Intn(len(recipes))])
+		}
+
+		node := mockNodeData{
+			Name:        fmt.Sprintf("%s-%03d.%s", prefix, i%100+1, domain),
+			IPAddress:   fmt.Sprintf("%d.%d.%d.%d", ipOctet1, ipOctet2, rng.Intn(256), rng.Intn(254)+1),
+			Environment: env,
+			OhaiTime:    ohaiTime,
+			RunList:     runList,
+		}
+		m.nodes = append(m.nodes, node)
+	}
+
+	sort.Slice(m.nodes, func(i, j int) bool {
+		return m.nodes[i].Name < m.nodes[j].Name
+	})
+}
+
+func (m *MockService) generateRoles() {
+	m.roles = map[string]*chef.Role{
+		"base": {
+			Name:        "base",
+			Description: "Base role applied to all nodes",
+			RunList:     []string{"recipe[base]", "recipe[monitoring::agent]"},
+			DefaultAttributes: map[string]interface{}{
+				"base": map[string]interface{}{
+					"timezone": "UTC",
+				},
+			},
+		},
+		"webserver": {
+			Name:        "webserver",
+			Description: "Web server configuration",
+			RunList:     []string{"role[base]", "recipe[nginx]", "recipe[ssl]"},
+			DefaultAttributes: map[string]interface{}{
+				"nginx": map[string]interface{}{
+					"worker_processes": 4,
+				},
+			},
+		},
+		"database": {
+			Name:        "database",
+			Description: "Database server configuration",
+			RunList:     []string{"role[base]", "recipe[postgresql]", "recipe[backup]"},
+			DefaultAttributes: map[string]interface{}{
+				"postgresql": map[string]interface{}{
+					"version": "14",
+				},
+			},
+		},
+		"monitoring": {
+			Name:        "monitoring",
+			Description: "Monitoring server with Prometheus and Grafana",
+			RunList:     []string{"role[base]", "recipe[prometheus]", "recipe[grafana]"},
+		},
+		"loadbalancer": {
+			Name:        "loadbalancer",
+			Description: "Load balancer with HAProxy",
+			RunList:     []string{"role[base]", "recipe[haproxy]"},
+		},
+	}
+}
+
+func (m *MockService) generateEnvironments() {
+	m.environments = map[string]*chef.Environment{
+		"production": {
+			Name:        "production",
+			Description: "Production environment",
+			CookbookVersions: map[string]string{
+				"apache2": "= 8.0.0",
+				"nginx":   "= 15.0.0",
+				"mysql":   ">= 10.0.0",
+			},
+			DefaultAttributes: map[string]interface{}{
+				"environment": "production",
+			},
+		},
+		"staging": {
+			Name:        "staging",
+			Description: "Staging environment for pre-production testing",
+			CookbookVersions: map[string]string{
+				"apache2": ">= 8.0.0",
+				"nginx":   ">= 15.0.0",
+			},
+			DefaultAttributes: map[string]interface{}{
+				"environment": "staging",
+			},
+		},
+		"development": {
+			Name:        "development",
+			Description: "Development environment",
+			DefaultAttributes: map[string]interface{}{
+				"environment": "development",
+			},
+		},
+		"qa": {
+			Name:        "qa",
+			Description: "QA testing environment",
+			DefaultAttributes: map[string]interface{}{
+				"environment": "qa",
+			},
+		},
+	}
+}
+
+func (m *MockService) generateCookbooks() {
+	m.cookbooks = map[string][]string{
+		"apache2":    {"8.0.0", "7.5.0", "7.4.0", "7.3.0"},
+		"nginx":      {"15.0.0", "14.2.0", "14.1.0"},
+		"mysql":      {"10.0.0", "9.5.0", "9.4.0", "9.3.0", "9.2.0"},
+		"postgresql": {"11.0.0", "10.5.0", "10.4.0"},
+		"redis":      {"8.0.0", "7.5.0", "7.4.0"},
+		"nodejs":     {"9.0.0", "8.5.0", "8.4.0"},
+		"python":     {"4.0.0", "3.5.0", "3.4.0"},
+		"java":       {"12.0.0", "11.5.0", "11.4.0"},
+		"monitoring": {"3.0.0", "2.5.0", "2.4.0"},
+		"base":       {"5.0.0", "4.5.0", "4.4.0", "4.3.0"},
+	}
+}
+
+func (m *MockService) generateDatabags() {
+	m.databags = map[string][]string{
+		"users":       {"admin", "deploy", "backup", "monitoring"},
+		"credentials": {"database", "api_keys", "ssl_certs"},
+		"app_config":  {"production", "staging", "development"},
+	}
+}
+
+func (m *MockService) generatePolicies() {
+	m.policies = map[string][]string{
+		"base":      {"abc123def456", "789ghi012jkl"},
+		"webserver": {"mno345pqr678"},
+		"database":  {"stu901vwx234", "yz567abc890"},
+	}
+
+	m.policyGroups = map[string]map[string]string{
+		"production": {
+			"base":      "abc123def456",
+			"webserver": "mno345pqr678",
+		},
+		"staging": {
+			"base":     "789ghi012jkl",
+			"database": "stu901vwx234",
+		},
+	}
+}
+
+func (m *MockService) generateGroups() {
+	m.groups = map[string]chef.Group{
+		"admins": {
+			Name:   "admins",
+			Actors: []string{"admin", "superuser"},
+			Groups: []string{},
+		},
+		"users": {
+			Name:   "users",
+			Actors: []string{"developer1", "developer2", "qa_user"},
+			Groups: []string{},
+		},
+		"clients": {
+			Name:   "clients",
+			Actors: []string{},
+			Groups: []string{},
+		},
+	}
+}
+
+// Node methods
+
+func (m *MockService) GetNodes(ctx context.Context) (*NodeList, error) {
+	names := make([]string, len(m.nodes))
+	for i, n := range m.nodes {
+		names[i] = n.Name
+	}
+	return &NodeList{Nodes: names}, nil
+}
+
+func (m *MockService) SearchNodes(ctx context.Context, q string) (*NodeList, error) {
+	var names []string
+	searchTerm := strings.ToLower(q)
+	for _, n := range m.nodes {
+		if strings.Contains(strings.ToLower(n.Name), searchTerm) ||
+			strings.Contains(strings.ToLower(n.Environment), searchTerm) ||
+			strings.Contains(n.IPAddress, searchTerm) {
+			names = append(names, n.Name)
+		}
+	}
+	return &NodeList{Nodes: names}, nil
+}
+
+func (m *MockService) GetNodesWithDetails(ctx context.Context, start, pageSize int) (*NodeListResult, error) {
+	return m.paginateNodes(m.nodes, start, pageSize)
+}
+
+func (m *MockService) SearchNodesWithDetails(ctx context.Context, q string, start, pageSize int) (*NodeListResult, error) {
+	var filtered []mockNodeData
+	searchTerm := strings.ToLower(q)
+	for _, n := range m.nodes {
+		if strings.Contains(strings.ToLower(n.Name), searchTerm) ||
+			strings.Contains(strings.ToLower(n.Environment), searchTerm) ||
+			strings.Contains(n.IPAddress, searchTerm) {
+			filtered = append(filtered, n)
+		}
+	}
+	return m.paginateNodes(filtered, start, pageSize)
+}
+
+func (m *MockService) paginateNodes(nodes []mockNodeData, start, pageSize int) (*NodeListResult, error) {
+	total := len(nodes)
+	if start >= total {
+		return &NodeListResult{
+			Nodes:    []NodeSummary{},
+			Total:    total,
+			Start:    start,
+			PageSize: pageSize,
+		}, nil
+	}
+
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+
+	page := nodes[start:end]
+	summaries := make([]NodeSummary, len(page))
+	for i, n := range page {
+		summaries[i] = NodeSummary{
+			Name:        n.Name,
+			IPAddress:   n.IPAddress,
+			Environment: n.Environment,
+			OhaiTime:    n.OhaiTime,
+		}
+	}
+
+	return &NodeListResult{
+		Nodes:    summaries,
+		Total:    total,
+		Start:    start,
+		PageSize: pageSize,
+	}, nil
+}
+
+func (m *MockService) GetNode(ctx context.Context, name string) (*Node, error) {
+	for _, n := range m.nodes {
+		if n.Name == name {
+			node := &Node{
+				Node: chef.Node{
+					Name:        n.Name,
+					Environment: n.Environment,
+					RunList:     n.RunList,
+					AutomaticAttributes: map[string]interface{}{
+						"ipaddress":        n.IPAddress,
+						"ohai_time":        n.OhaiTime,
+						"fqdn":             n.Name,
+						"hostname":         strings.Split(n.Name, ".")[0],
+						"platform":         "ubuntu",
+						"platform_version": "22.04",
+						"lsb": map[string]interface{}{
+							"description": "Ubuntu 22.04.3 LTS",
+						},
+						"chef_packages": map[string]interface{}{
+							"chef": map[string]interface{}{
+								"version": "18.2.7",
+							},
+						},
+					},
+					NormalAttributes:   map[string]interface{}{},
+					DefaultAttributes:  map[string]interface{}{},
+					OverrideAttributes: map[string]interface{}{},
+				},
+			}
+			node.MergedAttributes = node.MergeAttributes()
+			return node, nil
+		}
+	}
+	return nil, fmt.Errorf("node not found: %s", name)
+}
+
+// Role methods
+
+func (m *MockService) GetRoles(ctx context.Context) (*RoleList, error) {
+	names := make([]string, 0, len(m.roles))
+	for name := range m.roles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return &RoleList{Roles: names}, nil
+}
+
+func (m *MockService) GetRole(ctx context.Context, name string) (*Role, error) {
+	if role, ok := m.roles[name]; ok {
+		return &Role{Role: role}, nil
+	}
+	return nil, ErrRoleNotFound
+}
+
+// Environment methods
+
+func (m *MockService) GetEnvironments(ctx context.Context) (interface{}, error) {
+	result := make(map[string]string)
+	for name := range m.environments {
+		result[name] = fmt.Sprintf("/environments/%s", name)
+	}
+	return result, nil
+}
+
+func (m *MockService) GetEnvironment(ctx context.Context, name string) (*chef.Environment, error) {
+	if env, ok := m.environments[name]; ok {
+		return env, nil
+	}
+	return nil, fmt.Errorf("environment not found: %s", name)
+}
+
+// Cookbook methods
+
+func (m *MockService) GetCookbooks(ctx context.Context) (*CookbookListResult, error) {
+	var cookbooks []CookbookListItem
+	for name, versions := range m.cookbooks {
+		cookbooks = append(cookbooks, CookbookListItem{
+			Name:     name,
+			Versions: versions,
+		})
+	}
+	sort.Slice(cookbooks, func(i, j int) bool {
+		return cookbooks[i].Name < cookbooks[j].Name
+	})
+	return &CookbookListResult{Cookbooks: cookbooks}, nil
+}
+
+func (m *MockService) GetLatestCookbooks(ctx context.Context) (*CookbookListResult, error) {
+	var cookbooks []CookbookListItem
+	for name, versions := range m.cookbooks {
+		cookbooks = append(cookbooks, CookbookListItem{
+			Name:     name,
+			Versions: []string{versions[0]},
+		})
+	}
+	sort.Slice(cookbooks, func(i, j int) bool {
+		return cookbooks[i].Name < cookbooks[j].Name
+	})
+	return &CookbookListResult{Cookbooks: cookbooks}, nil
+}
+
+func (m *MockService) GetCookbook(ctx context.Context, name string) (*Cookbook, error) {
+	if versions, ok := m.cookbooks[name]; ok {
+		return m.GetCookbookVersion(ctx, name, versions[0])
+	}
+	return nil, ErrCookbookNotFound
+}
+
+func (m *MockService) GetCookbookVersion(ctx context.Context, name string, version string) (*Cookbook, error) {
+	versions, ok := m.cookbooks[name]
+	if !ok {
+		return nil, ErrCookbookNotFound
+	}
+
+	if version == "_latest" {
+		version = versions[0]
+	}
+
+	found := false
+	for _, v := range versions {
+		if v == version {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, ErrCookbookVersionNotFound
+	}
+
+	return &Cookbook{
+		Cookbook: chef.Cookbook{
+			CookbookName: name,
+			Name:         fmt.Sprintf("%s-%s", name, version),
+			Version:      version,
+			Metadata: chef.CookbookMeta{
+				Name:        name,
+				Version:     version,
+				Description: fmt.Sprintf("Mock %s cookbook", name),
+				License:     "Apache-2.0",
+				Maintainer:  "Mock Maintainer",
+			},
+			RootFiles: []chef.CookbookItem{
+				{Name: "README.md", Path: "README.md"},
+				{Name: "metadata.rb", Path: "metadata.rb"},
+			},
+			Recipes: []chef.CookbookItem{
+				{Name: "default.rb", Path: "recipes/default.rb"},
+			},
+			Attributes: []chef.CookbookItem{
+				{Name: "default.rb", Path: "attributes/default.rb"},
+			},
+		},
+	}, nil
+}
+
+func (m *MockService) GetCookbookVersions(ctx context.Context, name string) ([]string, error) {
+	versions, ok := m.cookbooks[name]
+	if !ok {
+		return nil, ErrCookbookNotFound
+	}
+	return versions, nil
+}
+
+// Databag methods
+
+func (m *MockService) GetDatabags(ctx context.Context) (interface{}, error) {
+	result := make(map[string]string)
+	for name := range m.databags {
+		result[name] = fmt.Sprintf("/data/%s", name)
+	}
+	return result, nil
+}
+
+func (m *MockService) GetDatabagItems(ctx context.Context, name string) (*chef.DataBagListResult, error) {
+	items, ok := m.databags[name]
+	if !ok {
+		return nil, fmt.Errorf("databag not found: %s", name)
+	}
+
+	result := make(chef.DataBagListResult)
+	for _, item := range items {
+		result[item] = fmt.Sprintf("/data/%s/%s", name, item)
+	}
+	return &result, nil
+}
+
+func (m *MockService) GetDatabagItemContent(ctx context.Context, databag string, item string) (chef.DataBagItem, error) {
+	items, ok := m.databags[databag]
+	if !ok {
+		return nil, fmt.Errorf("databag not found: %s", databag)
+	}
+
+	for _, i := range items {
+		if i == item {
+			return map[string]interface{}{
+				"id":      item,
+				"databag": databag,
+				"data":    "mock_value",
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("databag item not found: %s/%s", databag, item)
+}
+
+// Policy methods
+
+func (m *MockService) GetPolicies(ctx context.Context) (chef.PoliciesGetResponse, error) {
+	result := make(chef.PoliciesGetResponse)
+	for name, revisions := range m.policies {
+		revMap := make(map[string]interface{})
+		for _, rev := range revisions {
+			revMap[rev] = map[string]string{}
+		}
+		result[name] = chef.Policy{Revisions: revMap}
+	}
+	return result, nil
+}
+
+func (m *MockService) GetPolicy(ctx context.Context, name string) (chef.PolicyGetResponse, error) {
+	revisions, ok := m.policies[name]
+	if !ok {
+		return chef.PolicyGetResponse{}, fmt.Errorf("policy not found: %s", name)
+	}
+
+	result := make(chef.PolicyGetResponse)
+	for _, rev := range revisions {
+		result[rev] = chef.PolicyRevision{}
+	}
+
+	return result, nil
+}
+
+func (m *MockService) GetPolicyRevision(ctx context.Context, name string, revision string) (chef.RevisionDetailsResponse, error) {
+	revisions, ok := m.policies[name]
+	if !ok {
+		return chef.RevisionDetailsResponse{}, fmt.Errorf("policy not found: %s", name)
+	}
+
+	for _, rev := range revisions {
+		if rev == revision {
+			return chef.RevisionDetailsResponse{
+				Name:       name,
+				RevisionID: revision,
+			}, nil
+		}
+	}
+	return chef.RevisionDetailsResponse{}, fmt.Errorf("policy revision not found: %s/%s", name, revision)
+}
+
+func (m *MockService) GetPolicyGroups(ctx context.Context) (chef.PolicyGroupGetResponse, error) {
+	result := make(chef.PolicyGroupGetResponse)
+	for groupName, policies := range m.policyGroups {
+		policyMap := make(map[string]chef.Revision)
+		for policyName, revisionID := range policies {
+			policyMap[policyName] = chef.Revision{"revision_id": revisionID}
+		}
+		result[groupName] = chef.PolicyGroup{
+			Policies: policyMap,
+		}
+	}
+	return result, nil
+}
+
+func (m *MockService) GetPolicyGroup(ctx context.Context, name string) (PolicyGroup, error) {
+	policies, ok := m.policyGroups[name]
+	if !ok {
+		return PolicyGroup{}, fmt.Errorf("policy group not found: %s", name)
+	}
+
+	policyMap := make(map[string]chef.Revision)
+	for policyName, revisionID := range policies {
+		policyMap[policyName] = chef.Revision{"revision_id": revisionID}
+	}
+
+	return PolicyGroup{
+		PolicyGroup: chef.PolicyGroup{
+			Policies: policyMap,
+		},
+	}, nil
+}
+
+// Group methods
+
+func (m *MockService) GetGroups(ctx context.Context) (interface{}, error) {
+	result := make(map[string]string)
+	for name := range m.groups {
+		result[name] = fmt.Sprintf("/groups/%s", name)
+	}
+	return result, nil
+}
+
+func (m *MockService) GetGroup(ctx context.Context, name string) (chef.Group, error) {
+	if group, ok := m.groups[name]; ok {
+		return group, nil
+	}
+	return chef.Group{}, fmt.Errorf("group not found: %s", name)
+}

--- a/internal/chef/mock.go
+++ b/internal/chef/mock.go
@@ -250,8 +250,6 @@ func (m *MockService) generateGroups() {
 	}
 }
 
-// Node methods
-
 func (m *MockService) GetNodes(ctx context.Context) (*NodeList, error) {
 	names := make([]string, len(m.nodes))
 	for i, n := range m.nodes {
@@ -361,8 +359,6 @@ func (m *MockService) GetNode(ctx context.Context, name string) (*Node, error) {
 	return nil, fmt.Errorf("node not found: %s", name)
 }
 
-// Role methods
-
 func (m *MockService) GetRoles(ctx context.Context) (*RoleList, error) {
 	names := make([]string, 0, len(m.roles))
 	for name := range m.roles {
@@ -379,8 +375,6 @@ func (m *MockService) GetRole(ctx context.Context, name string) (*Role, error) {
 	return nil, ErrRoleNotFound
 }
 
-// Environment methods
-
 func (m *MockService) GetEnvironments(ctx context.Context) (interface{}, error) {
 	result := make(map[string]string)
 	for name := range m.environments {
@@ -395,8 +389,6 @@ func (m *MockService) GetEnvironment(ctx context.Context, name string) (*chef.En
 	}
 	return nil, fmt.Errorf("environment not found: %s", name)
 }
-
-// Cookbook methods
 
 func (m *MockService) GetCookbooks(ctx context.Context) (*CookbookListResult, error) {
 	var cookbooks []CookbookListItem
@@ -488,8 +480,6 @@ func (m *MockService) GetCookbookVersions(ctx context.Context, name string) ([]s
 	return versions, nil
 }
 
-// Databag methods
-
 func (m *MockService) GetDatabags(ctx context.Context) (interface{}, error) {
 	result := make(map[string]string)
 	for name := range m.databags {
@@ -528,8 +518,6 @@ func (m *MockService) GetDatabagItemContent(ctx context.Context, databag string,
 	}
 	return nil, fmt.Errorf("databag item not found: %s/%s", databag, item)
 }
-
-// Policy methods
 
 func (m *MockService) GetPolicies(ctx context.Context) (chef.PoliciesGetResponse, error) {
 	result := make(chef.PoliciesGetResponse)
@@ -605,8 +593,6 @@ func (m *MockService) GetPolicyGroup(ctx context.Context, name string) (PolicyGr
 		},
 	}, nil
 }
-
-// Group methods
 
 func (m *MockService) GetGroups(ctx context.Context) (interface{}, error) {
 	result := make(map[string]string)

--- a/internal/chef/mock.go
+++ b/internal/chef/mock.go
@@ -250,7 +250,7 @@ func (m *MockService) generateGroups() {
 	}
 }
 
-func (m *MockService) GetNodes(ctx context.Context) (*NodeList, error) {
+func (m *MockService) GetNodes(context.Context) (*NodeList, error) {
 	names := make([]string, len(m.nodes))
 	for i, n := range m.nodes {
 		names[i] = n.Name
@@ -258,7 +258,7 @@ func (m *MockService) GetNodes(ctx context.Context) (*NodeList, error) {
 	return &NodeList{Nodes: names}, nil
 }
 
-func (m *MockService) SearchNodes(ctx context.Context, q string) (*NodeList, error) {
+func (m *MockService) SearchNodes(_ context.Context, q string) (*NodeList, error) {
 	var names []string
 	for _, n := range m.nodes {
 		if m.nodeMatchesQuery(n, q) {
@@ -268,11 +268,11 @@ func (m *MockService) SearchNodes(ctx context.Context, q string) (*NodeList, err
 	return &NodeList{Nodes: names}, nil
 }
 
-func (m *MockService) GetNodesWithDetails(ctx context.Context, start, pageSize int) (*NodeListResult, error) {
+func (m *MockService) GetNodesWithDetails(_ context.Context, start, pageSize int) (*NodeListResult, error) {
 	return m.paginateNodes(m.nodes, start, pageSize)
 }
 
-func (m *MockService) SearchNodesWithDetails(ctx context.Context, q string, start, pageSize int) (*NodeListResult, error) {
+func (m *MockService) SearchNodesWithDetails(_ context.Context, q string, start, pageSize int) (*NodeListResult, error) {
 	var filtered []mockNodeData
 	for _, n := range m.nodes {
 		if m.nodeMatchesQuery(n, q) {
@@ -374,7 +374,7 @@ func (m *MockService) paginateNodes(nodes []mockNodeData, start, pageSize int) (
 	}, nil
 }
 
-func (m *MockService) GetNode(ctx context.Context, name string) (*Node, error) {
+func (m *MockService) GetNode(_ context.Context, name string) (*Node, error) {
 	for _, n := range m.nodes {
 		if n.Name == name {
 			node := &Node{
@@ -410,7 +410,7 @@ func (m *MockService) GetNode(ctx context.Context, name string) (*Node, error) {
 	return nil, fmt.Errorf("node not found: %s", name)
 }
 
-func (m *MockService) GetRoles(ctx context.Context) (*RoleList, error) {
+func (m *MockService) GetRoles(context.Context) (*RoleList, error) {
 	names := make([]string, 0, len(m.roles))
 	for name := range m.roles {
 		names = append(names, name)
@@ -419,14 +419,14 @@ func (m *MockService) GetRoles(ctx context.Context) (*RoleList, error) {
 	return &RoleList{Roles: names}, nil
 }
 
-func (m *MockService) GetRole(ctx context.Context, name string) (*Role, error) {
+func (m *MockService) GetRole(_ context.Context, name string) (*Role, error) {
 	if role, ok := m.roles[name]; ok {
 		return &Role{Role: role}, nil
 	}
 	return nil, ErrRoleNotFound
 }
 
-func (m *MockService) GetEnvironments(ctx context.Context) (interface{}, error) {
+func (m *MockService) GetEnvironments(context.Context) (interface{}, error) {
 	result := make(map[string]string)
 	for name := range m.environments {
 		result[name] = fmt.Sprintf("/environments/%s", name)
@@ -434,14 +434,14 @@ func (m *MockService) GetEnvironments(ctx context.Context) (interface{}, error) 
 	return result, nil
 }
 
-func (m *MockService) GetEnvironment(ctx context.Context, name string) (*chef.Environment, error) {
+func (m *MockService) GetEnvironment(_ context.Context, name string) (*chef.Environment, error) {
 	if env, ok := m.environments[name]; ok {
 		return env, nil
 	}
 	return nil, fmt.Errorf("environment not found: %s", name)
 }
 
-func (m *MockService) GetCookbooks(ctx context.Context) (*CookbookListResult, error) {
+func (m *MockService) GetCookbooks(context.Context) (*CookbookListResult, error) {
 	var cookbooks []CookbookListItem
 	for name, versions := range m.cookbooks {
 		cookbooks = append(cookbooks, CookbookListItem{
@@ -455,7 +455,7 @@ func (m *MockService) GetCookbooks(ctx context.Context) (*CookbookListResult, er
 	return &CookbookListResult{Cookbooks: cookbooks}, nil
 }
 
-func (m *MockService) GetLatestCookbooks(ctx context.Context) (*CookbookListResult, error) {
+func (m *MockService) GetLatestCookbooks(context.Context) (*CookbookListResult, error) {
 	var cookbooks []CookbookListItem
 	for name, versions := range m.cookbooks {
 		cookbooks = append(cookbooks, CookbookListItem{
@@ -476,7 +476,7 @@ func (m *MockService) GetCookbook(ctx context.Context, name string) (*Cookbook, 
 	return nil, ErrCookbookNotFound
 }
 
-func (m *MockService) GetCookbookVersion(ctx context.Context, name string, version string) (*Cookbook, error) {
+func (m *MockService) GetCookbookVersion(_ context.Context, name string, version string) (*Cookbook, error) {
 	versions, ok := m.cookbooks[name]
 	if !ok {
 		return nil, ErrCookbookNotFound
@@ -523,7 +523,7 @@ func (m *MockService) GetCookbookVersion(ctx context.Context, name string, versi
 	}, nil
 }
 
-func (m *MockService) GetCookbookVersions(ctx context.Context, name string) ([]string, error) {
+func (m *MockService) GetCookbookVersions(_ context.Context, name string) ([]string, error) {
 	versions, ok := m.cookbooks[name]
 	if !ok {
 		return nil, ErrCookbookNotFound
@@ -531,7 +531,7 @@ func (m *MockService) GetCookbookVersions(ctx context.Context, name string) ([]s
 	return versions, nil
 }
 
-func (m *MockService) GetDatabags(ctx context.Context) (interface{}, error) {
+func (m *MockService) GetDatabags(context.Context) (interface{}, error) {
 	result := make(map[string]string)
 	for name := range m.databags {
 		result[name] = fmt.Sprintf("/data/%s", name)
@@ -539,7 +539,7 @@ func (m *MockService) GetDatabags(ctx context.Context) (interface{}, error) {
 	return result, nil
 }
 
-func (m *MockService) GetDatabagItems(ctx context.Context, name string) (*chef.DataBagListResult, error) {
+func (m *MockService) GetDatabagItems(_ context.Context, name string) (*chef.DataBagListResult, error) {
 	items, ok := m.databags[name]
 	if !ok {
 		return nil, fmt.Errorf("databag not found: %s", name)
@@ -552,7 +552,7 @@ func (m *MockService) GetDatabagItems(ctx context.Context, name string) (*chef.D
 	return &result, nil
 }
 
-func (m *MockService) GetDatabagItemContent(ctx context.Context, databag string, item string) (chef.DataBagItem, error) {
+func (m *MockService) GetDatabagItemContent(_ context.Context, databag string, item string) (chef.DataBagItem, error) {
 	items, ok := m.databags[databag]
 	if !ok {
 		return nil, fmt.Errorf("databag not found: %s", databag)
@@ -570,7 +570,7 @@ func (m *MockService) GetDatabagItemContent(ctx context.Context, databag string,
 	return nil, fmt.Errorf("databag item not found: %s/%s", databag, item)
 }
 
-func (m *MockService) GetPolicies(ctx context.Context) (chef.PoliciesGetResponse, error) {
+func (m *MockService) GetPolicies(context.Context) (chef.PoliciesGetResponse, error) {
 	result := make(chef.PoliciesGetResponse)
 	for name, revisions := range m.policies {
 		revMap := make(map[string]interface{})
@@ -582,7 +582,7 @@ func (m *MockService) GetPolicies(ctx context.Context) (chef.PoliciesGetResponse
 	return result, nil
 }
 
-func (m *MockService) GetPolicy(ctx context.Context, name string) (chef.PolicyGetResponse, error) {
+func (m *MockService) GetPolicy(_ context.Context, name string) (chef.PolicyGetResponse, error) {
 	revisions, ok := m.policies[name]
 	if !ok {
 		return chef.PolicyGetResponse{}, fmt.Errorf("policy not found: %s", name)
@@ -596,7 +596,7 @@ func (m *MockService) GetPolicy(ctx context.Context, name string) (chef.PolicyGe
 	return result, nil
 }
 
-func (m *MockService) GetPolicyRevision(ctx context.Context, name string, revision string) (chef.RevisionDetailsResponse, error) {
+func (m *MockService) GetPolicyRevision(_ context.Context, name string, revision string) (chef.RevisionDetailsResponse, error) {
 	revisions, ok := m.policies[name]
 	if !ok {
 		return chef.RevisionDetailsResponse{}, fmt.Errorf("policy not found: %s", name)
@@ -613,7 +613,7 @@ func (m *MockService) GetPolicyRevision(ctx context.Context, name string, revisi
 	return chef.RevisionDetailsResponse{}, fmt.Errorf("policy revision not found: %s/%s", name, revision)
 }
 
-func (m *MockService) GetPolicyGroups(ctx context.Context) (chef.PolicyGroupGetResponse, error) {
+func (m *MockService) GetPolicyGroups(context.Context) (chef.PolicyGroupGetResponse, error) {
 	result := make(chef.PolicyGroupGetResponse)
 	for groupName, policies := range m.policyGroups {
 		policyMap := make(map[string]chef.Revision)
@@ -627,7 +627,7 @@ func (m *MockService) GetPolicyGroups(ctx context.Context) (chef.PolicyGroupGetR
 	return result, nil
 }
 
-func (m *MockService) GetPolicyGroup(ctx context.Context, name string) (PolicyGroup, error) {
+func (m *MockService) GetPolicyGroup(_ context.Context, name string) (PolicyGroup, error) {
 	policies, ok := m.policyGroups[name]
 	if !ok {
 		return PolicyGroup{}, fmt.Errorf("policy group not found: %s", name)
@@ -645,7 +645,7 @@ func (m *MockService) GetPolicyGroup(ctx context.Context, name string) (PolicyGr
 	}, nil
 }
 
-func (m *MockService) GetGroups(ctx context.Context) (interface{}, error) {
+func (m *MockService) GetGroups(context.Context) (interface{}, error) {
 	result := make(map[string]string)
 	for name := range m.groups {
 		result[name] = fmt.Sprintf("/groups/%s", name)
@@ -653,7 +653,7 @@ func (m *MockService) GetGroups(ctx context.Context) (interface{}, error) {
 	return result, nil
 }
 
-func (m *MockService) GetGroup(ctx context.Context, name string) (chef.Group, error) {
+func (m *MockService) GetGroup(_ context.Context, name string) (chef.Group, error) {
 	if group, ok := m.groups[name]; ok {
 		return group, nil
 	}

--- a/internal/chef/mock_test.go
+++ b/internal/chef/mock_test.go
@@ -1,0 +1,75 @@
+package chef
+
+import (
+	"context"
+	"testing"
+
+	"github.com/drewhammond/chefbrowser/internal/common/logging"
+	"go.uber.org/zap"
+)
+
+func newTestMockService() *MockService {
+	log := &logging.Logger{Logger: zap.NewNop()}
+	return NewMockService(log)
+}
+
+func TestMockService_SearchNodesWithDetails(t *testing.T) {
+	m := newTestMockService()
+
+	tests := []struct {
+		name        string
+		query       string
+		expectCount bool
+	}{
+		{
+			name:        "match all",
+			query:       "*:*",
+			expectCount: true,
+		},
+		{
+			name:        "fqdn search",
+			query:       "fqdn:*web*",
+			expectCount: true,
+		},
+		{
+			name:        "roles search",
+			query:       "roles:*base*",
+			expectCount: true,
+		},
+		{
+			name:        "addresses search",
+			query:       "addresses:*10.*",
+			expectCount: true,
+		},
+		{
+			name:        "multi-term OR search",
+			query:       "fqdn:*web* OR roles:*database*",
+			expectCount: true,
+		},
+		{
+			name:        "no match",
+			query:       "fqdn:*nonexistent*",
+			expectCount: false,
+		},
+		{
+			name:        "plain text search",
+			query:       "web",
+			expectCount: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := m.SearchNodesWithDetails(context.Background(), tt.query, 0, 100)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.expectCount && result.Total == 0 {
+				t.Errorf("expected results for query %q, got 0", tt.query)
+			}
+			if !tt.expectCount && result.Total > 0 {
+				t.Errorf("expected no results for query %q, got %d", tt.query, result.Total)
+			}
+		})
+	}
+}

--- a/ui/src/scss/bootstrap.scss
+++ b/ui/src/scss/bootstrap.scss
@@ -31,7 +31,7 @@
 //@import "~bootstrap/scss/card";
 //@import "~bootstrap/scss/accordion";
 //@import "~bootstrap/scss/breadcrumb";
-//@import "~bootstrap/scss/pagination";
+@import "~bootstrap/scss/pagination";
 @import "~bootstrap/scss/badge";
 //@import "~bootstrap/scss/alert";
 //@import "~bootstrap/scss/progress";

--- a/ui/src/scss/custom.scss
+++ b/ui/src/scss/custom.scss
@@ -49,12 +49,12 @@ pre code.hljs {
   font-weight: 400;
 }
 
-.dark-mode-toggle > .form-check-input {
-  border-radius: 2em;
+#theme-toggle {
+  text-decoration: none;
 }
 
-.dark-mode-toggle > label, input {
-  cursor: pointer;
+#theme-toggle:hover {
+  opacity: 0.8;
 }
 
 .cb-cookbook-version-badge {
@@ -88,15 +88,19 @@ $color-mode-type: data;
     color: var(--bs-tertiary-color);
   }
 
-  #enable-dark-mode {
-    background-color: var(--bs-tertiary-bg);
-    border-color: var(--bs-secondary-color);
-  }
-
   @import 'highlight.js/scss/base16/default-dark';
   .hljs-ln td.hljs-ln-numbers {
     color: var(--bs-tertiary-color);
     border-right-color: var(--bs-tertiary-color);
+  }
+
+  .table {
+    --bs-table-bg: var(--bs-body-bg);
+    --bs-table-hover-bg: var(--bs-tertiary-bg);
+  }
+
+  .table > thead {
+    background-color: var(--bs-tertiary-bg);
   }
 }
 

--- a/ui/src/scss/custom.scss
+++ b/ui/src/scss/custom.scss
@@ -118,3 +118,33 @@ $color-mode-type: data;
   width: 2.5em;
   vertical-align: -0.125em;
 }
+
+.nodes-table {
+  table-layout: fixed;
+
+  th.sortable {
+    user-select: none;
+
+    .sort-icon {
+      font-size: 0.7em;
+      opacity: 0.6;
+    }
+  }
+
+  th.resizable {
+    position: relative;
+
+    .col-resizer {
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 5px;
+      cursor: col-resize;
+
+      &:hover {
+        background-color: var(--bs-primary);
+      }
+    }
+  }
+}

--- a/ui/templates/cookbooks.html
+++ b/ui/templates/cookbooks.html
@@ -2,6 +2,15 @@
   cookbooks
 {{ end }}
 {{ define "content"}}
+  {{ if not .cookbooks }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783"/>
+    </svg>
+    <h4 class="text-muted">No cookbooks found</h4>
+    <p class="text-muted">There are no cookbooks on this Chef server.</p>
+  </div>
+  {{ else }}
   <h2>Cookbooks <small class="text-muted">({{ len .cookbooks }})</small></h2>
   <ul id="cookbook-list" class="list-unstyled">
       {{ range $index, $versions := .cookbooks}}
@@ -13,4 +22,5 @@
         </li>
       {{ end }}
   </ul>
+  {{ end }}
 {{ end }}

--- a/ui/templates/databags.html
+++ b/ui/templates/databags.html
@@ -1,8 +1,18 @@
 {{ define "content"}}
+  {{ if not .databags }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M4.98 4a.5.5 0 0 0-.39.188L1.54 8H6a.5.5 0 0 1 .5.5 1.5 1.5 0 1 0 3 0A.5.5 0 0 1 10 8h4.46l-3.05-3.812A.5.5 0 0 0 11.02 4zm9.954 5H10.45a2.5 2.5 0 0 1-4.9 0H1.066l.32 2.562a.5.5 0 0 0 .497.438h12.234a.5.5 0 0 0 .496-.438zM3.809 3.563A1.5 1.5 0 0 1 4.981 3h6.038a1.5 1.5 0 0 1 1.172.563l3.7 4.625a.5.5 0 0 1 .105.374l-.39 3.124A1.5 1.5 0 0 1 14.117 13H1.883a1.5 1.5 0 0 1-1.489-1.314l-.39-3.124a.5.5 0 0 1 .106-.374z"/>
+    </svg>
+    <h4 class="text-muted">No data bags found</h4>
+    <p class="text-muted">There are no data bags on this Chef server.</p>
+  </div>
+  {{ else }}
   <h2>Data Bags <small class="text-muted">({{ len .databags }})</small></h2>
   <ul id="databag-list" class="list-unstyled">
       {{ range $name, $url := .databags}}
         <li><a href="{{ base_path }}/ui/databags/{{$name}}">{{$name}}</a></li>
       {{ end }}
   </ul>
+  {{ end }}
 {{ end }}

--- a/ui/templates/environments.html
+++ b/ui/templates/environments.html
@@ -1,8 +1,18 @@
 {{ define "content"}}
+  {{ if not .environments }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M6.5 1A1.5 1.5 0 0 0 5 2.5V3H1.5A1.5 1.5 0 0 0 0 4.5v8A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-8A1.5 1.5 0 0 0 14.5 3H11v-.5A1.5 1.5 0 0 0 9.5 1zm0 1h3a.5.5 0 0 1 .5.5V3H6v-.5a.5.5 0 0 1 .5-.5m1.886 6.914L15 7.151V12.5a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5V7.15l6.614 1.764a1.5 1.5 0 0 0 .772 0M1.5 4h13a.5.5 0 0 1 .5.5v1.616l-6.614 1.764a.5.5 0 0 1-.772 0L1 6.116V4.5a.5.5 0 0 1 .5-.5"/>
+    </svg>
+    <h4 class="text-muted">No environments found</h4>
+    <p class="text-muted">There are no environments on this Chef server.</p>
+  </div>
+  {{ else }}
   <h2>Environments <small class="text-muted">({{ len .environments }})</small></h2>
   <ul id="environment-list" class="list-unstyled">
       {{ range $name, $url := .environments }}
         <li><a href="{{ base_path }}/ui/environments/{{$name}}">{{$name}}</a></li>
       {{ end }}
   </ul>
+  {{ end }}
 {{ end }}

--- a/ui/templates/groups.html
+++ b/ui/templates/groups.html
@@ -1,14 +1,18 @@
 {{ define "content"}}
-  <h2>Groups</h2>
-  {{ range $name, $url := .groups}}
-      {{.}}
-
-      {{ $url }}
-
-  {{ end }}
-  <ul id="node-list" class="list-unstyled">
-      {{/*        {{ range .groups }}*/}}
-      {{/*      {{.}}*/}}
-      {{/*        {{ end }}*/}}
+  {{ if not .groups }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1zm-7.978-1L7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002-.014.002zM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4m3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0M6.936 9.28a6 6 0 0 0-1.23-.247A7 7 0 0 0 5 9c-4 0-5 3-5 4q0 1 1 1h4.216A2.24 2.24 0 0 1 5 13c0-1.01.377-2.042 1.09-2.904.243-.294.526-.569.846-.816M4.92 10A5.5 5.5 0 0 0 4 13H1c0-.26.164-1.03.76-1.724.545-.636 1.492-1.256 3.16-1.275ZM1.5 5.5a3 3 0 1 1 6 0 3 3 0 0 1-6 0m3-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4"/>
+    </svg>
+    <h4 class="text-muted">No groups found</h4>
+    <p class="text-muted">There are no groups on this Chef server.</p>
+  </div>
+  {{ else }}
+  <h2>Groups <small class="text-muted">({{ len .groups }})</small></h2>
+  <ul id="group-list" class="list-unstyled">
+      {{ range $name, $url := .groups}}
+        <li><a href="{{ base_path }}/ui/groups/{{$name}}">{{$name}}</a></li>
+      {{ end }}
   </ul>
+  {{ end }}
 {{ end }}

--- a/ui/templates/layouts/footer.html
+++ b/ui/templates/layouts/footer.html
@@ -1,16 +1,8 @@
 <footer class="footer mt-auto py-3 cb-footer">
   <div class="container">
-    <div class="d-flex flex-row justify-content-between">
-			<span class="text-muted">
-				<a target="_blank" href="https://github.com/drewhammond/chefbrowser">Chef Browser</a> v{{ app_version }}
-			</span>
-      <div class="d-flex">
-        <div id="bd-theme" class="form-check form-switch dark-mode-toggle">
-          <input class="form-check-input" type="checkbox" id="enable-dark-mode" data-bs-theme-value="light">
-          <label id="bd-theme-text" class="form-check-label" for="enable-dark-mode">Dark Mode</label>
-        </div>
-      </div>
-    </div>
+    <span class="text-muted">
+      <a target="_blank" href="https://github.com/drewhammond/chefbrowser">Chef Browser</a> v{{ app_version }}
+    </span>
   </div>
 </footer>
 <button id="btn-scroll-to-top" class="btn border-0" aria-label="Back to Top">

--- a/ui/templates/layouts/master.html
+++ b/ui/templates/layouts/master.html
@@ -18,7 +18,6 @@
         if (storedTheme) {
           return storedTheme
         }
-
         return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
       }
 
@@ -30,32 +29,40 @@
         }
       }
 
+      const updateIcons = (theme) => {
+        const sunIcon = document.getElementById('theme-icon-sun')
+        const moonIcon = document.getElementById('theme-icon-moon')
+        if (sunIcon && moonIcon) {
+          sunIcon.style.display = theme === 'dark' ? 'block' : 'none'
+          moonIcon.style.display = theme === 'light' ? 'block' : 'none'
+        }
+      }
+
       setTheme(getPreferredTheme())
 
       window.addEventListener('DOMContentLoaded', () => {
-        const toggle = document.querySelector('#enable-dark-mode')
-        const storedTheme = getStoredTheme()
-        toggle.checked = storedTheme === 'dark'
-        toggle.setAttribute('data-bs-theme-value', storedTheme === 'dark' ? 'light' : 'dark')
+        const toggle = document.getElementById('theme-toggle')
+        const currentTheme = getPreferredTheme()
+        updateIcons(currentTheme)
 
-        toggle.addEventListener('change', () => {
-          const theme = toggle.getAttribute('data-bs-theme-value')
-          setStoredTheme(theme)
-          setTheme(theme)
-          toggle.setAttribute('data-bs-theme-value', theme === 'light' ? 'dark' : 'light')
+        toggle.addEventListener('click', () => {
+          const currentTheme = document.documentElement.getAttribute('data-bs-theme')
+          const newTheme = currentTheme === 'dark' ? 'light' : 'dark'
+          setStoredTheme(newTheme)
+          setTheme(newTheme)
+          updateIcons(newTheme)
         })
-
-        setTheme(getPreferredTheme())
       })
 
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
         const storedTheme = getStoredTheme()
         if (storedTheme !== 'light' && storedTheme !== 'dark') {
-          setTheme(getPreferredTheme())
+          const theme = getPreferredTheme()
+          setTheme(theme)
+          updateIcons(theme)
         }
       })
     })()
-
   </script>
     {{ include "layouts/head"}}
   <link rel="alternate icon" class="js-site-favicon" type="image/png" href="{{ base_path }}/ui/favicons/favicon.png">

--- a/ui/templates/layouts/nav.html
+++ b/ui/templates/layouts/nav.html
@@ -40,6 +40,14 @@
               document.getElementById("search-box").value = value
             </script>
           {{ end }}
+        <button id="theme-toggle" class="btn btn-link nav-link ms-2 px-2 py-1" type="button" aria-label="Toggle theme">
+          <svg id="theme-icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 16 16" style="display: none;">
+            <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/>
+          </svg>
+          <svg id="theme-icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#adb5bd" viewBox="0 0 16 16" style="display: none;">
+            <path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278"/>
+          </svg>
+        </button>
       </div>
     </div>
   </nav>

--- a/ui/templates/nodes.html
+++ b/ui/templates/nodes.html
@@ -1,8 +1,134 @@
 {{ define "content"}}
-  <h2>Nodes <small class="text-muted">({{ len .nodes }})</small></h2>
-  <ul id="node-list" class="list-unstyled">
-      {{ range .nodes }}
-        <li><a href="{{ base_path }}/ui/nodes/{{.}}">{{.}}</a></li>
+  {{ if eq .total 0 }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M4 2v2H2V2zm1 12v-2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1m0-5V7a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1m0-5V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1m5 10v-2a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1m0-5V7a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1m0-5V2a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1M9 2v2H7V2zm5 0v2h-2V2zM4 7v2H2V7zm5 0v2H7V7zm5 0h-2v2h2zM4 12v2H2v-2zm5 0v2H7v-2zm5 0v2h-2v-2zM15 1a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zm0 5a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1zm0 5a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1z"/>
+    </svg>
+    <h4 class="text-muted">No nodes found</h4>
+    {{ if .query }}
+    <p class="text-muted">No results for "{{ .query }}"</p>
+    <a href="{{ base_path }}/ui/nodes" class="btn btn-outline-secondary btn-sm">Clear search</a>
+    {{ else }}
+    <p class="text-muted">There are no nodes registered on this Chef server.</p>
+    {{ end }}
+  </div>
+  {{ else }}
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Nodes <small class="text-muted">({{ .total }})</small></h2>
+    <div class="d-flex gap-2 align-items-center">
+      <input type="text" id="table-filter" class="form-control form-control-sm" placeholder="Filter this page..." style="width: 200px;">
+      <select id="per-page-select" class="form-select form-select-sm" style="width: auto;">
+        <option value="50"{{ if eq .per_page 50 }} selected{{ end }}>50</option>
+        <option value="100"{{ if eq .per_page 100 }} selected{{ end }}>100</option>
+        <option value="500"{{ if eq .per_page 500 }} selected{{ end }}>500</option>
+        <option value="1000"{{ if eq .per_page 1000 }} selected{{ end }}>1000</option>
+      </select>
+    </div>
+  </div>
+
+  {{ if gt .total_pages 1 }}
+  <nav aria-label="Node pagination" class="mb-3">
+    <ul class="pagination pagination-sm mb-0">
+      {{ if gt .page 1 }}
+      <li class="page-item">
+        <a class="page-link" href="{{ base_path }}/ui/nodes?page={{ sub .page 1 }}{{ if .query }}&q={{ .query }}{{ end }}&per_page={{ .per_page }}">Previous</a>
+      </li>
+      {{ else }}
+      <li class="page-item disabled"><span class="page-link">Previous</span></li>
       {{ end }}
-  </ul>
+
+      <li class="page-item disabled"><span class="page-link">Page {{ .page }} of {{ .total_pages }}</span></li>
+
+      {{ if lt .page .total_pages }}
+      <li class="page-item">
+        <a class="page-link" href="{{ base_path }}/ui/nodes?page={{ add .page 1 }}{{ if .query }}&q={{ .query }}{{ end }}&per_page={{ .per_page }}">Next</a>
+      </li>
+      {{ else }}
+      <li class="page-item disabled"><span class="page-link">Next</span></li>
+      {{ end }}
+    </ul>
+  </nav>
+  {{ end }}
+
+  <div class="table-responsive">
+    <table class="table table-hover table-sm" id="nodes-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>IP Address</th>
+          <th>Last Run</th>
+          <th>Environment</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .nodes }}
+        <tr>
+          <td><a href="{{ base_path }}/ui/nodes/{{ .Name }}">{{ .Name }}</a></td>
+          <td>{{ if .IPAddress }}{{ .IPAddress }}{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+          <td class="last-run-cell" data-ohai-time="{{ .OhaiTime }}">{{ if .OhaiTime }}<span class="text-muted">-</span>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+          <td>{{ if .Environment }}<a href="{{ base_path }}/ui/environments/{{ .Environment }}">{{ .Environment }}</a>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+
+  {{ if gt .total_pages 1 }}
+  <nav aria-label="Node pagination">
+    <ul class="pagination pagination-sm">
+      {{ if gt .page 1 }}
+      <li class="page-item">
+        <a class="page-link" href="{{ base_path }}/ui/nodes?page={{ sub .page 1 }}{{ if .query }}&q={{ .query }}{{ end }}&per_page={{ .per_page }}">Previous</a>
+      </li>
+      {{ else }}
+      <li class="page-item disabled"><span class="page-link">Previous</span></li>
+      {{ end }}
+
+      <li class="page-item disabled"><span class="page-link">Page {{ .page }} of {{ .total_pages }}</span></li>
+
+      {{ if lt .page .total_pages }}
+      <li class="page-item">
+        <a class="page-link" href="{{ base_path }}/ui/nodes?page={{ add .page 1 }}{{ if .query }}&q={{ .query }}{{ end }}&per_page={{ .per_page }}">Next</a>
+      </li>
+      {{ else }}
+      <li class="page-item disabled"><span class="page-link">Next</span></li>
+      {{ end }}
+    </ul>
+  </nav>
+  {{ end }}
+  {{ end }}
+
+  <script type="module">
+    // Format last run times
+    document.querySelectorAll('.last-run-cell').forEach(cell => {
+      const ohaiTime = parseFloat(cell.dataset.ohaiTime);
+      if (ohaiTime && ohaiTime > 0) {
+        const lastRun = dayjs.unix(ohaiTime);
+        cell.textContent = dayjs().to(lastRun);
+        cell.title = lastRun.format('YYYY-MM-DD HH:mm:ss');
+      }
+    });
+
+    // Client-side table filtering
+    const filterInput = document.getElementById('table-filter');
+    const tableBody = document.querySelector('#nodes-table tbody');
+    const rows = tableBody.querySelectorAll('tr');
+
+    filterInput.addEventListener('input', (e) => {
+      const filter = e.target.value.toLowerCase();
+      rows.forEach(row => {
+        const text = row.textContent.toLowerCase();
+        row.style.display = text.includes(filter) ? '' : 'none';
+      });
+    });
+
+    // Per-page selector
+    const perPageSelect = document.getElementById('per-page-select');
+    perPageSelect.addEventListener('change', (e) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('per_page', e.target.value);
+      url.searchParams.set('page', '1');
+      window.location.href = url.toString();
+    });
+  </script>
 {{ end }}

--- a/ui/templates/nodes.html
+++ b/ui/templates/nodes.html
@@ -18,7 +18,7 @@
     <div class="d-flex gap-2 align-items-center">
       <input type="text" id="table-filter" class="form-control form-control-sm" placeholder="Filter this page..." style="width: 200px;">
       <div class="dropdown">
-        <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+        <button class="btn btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" style="border: 1px solid var(--bs-border-color); background-color: var(--bs-body-bg);">
           Columns
         </button>
         <ul class="dropdown-menu dropdown-menu-end" id="column-toggles">
@@ -29,6 +29,7 @@
         </ul>
       </div>
       <select id="per-page-select" class="form-select form-select-sm" style="width: auto;">
+        <option value="0"{{ if eq .per_page 0 }} selected{{ end }}>All</option>
         <option value="50"{{ if eq .per_page 50 }} selected{{ end }}>50</option>
         <option value="100"{{ if eq .per_page 100 }} selected{{ end }}>100</option>
         <option value="500"{{ if eq .per_page 500 }} selected{{ end }}>500</option>

--- a/ui/templates/nodes.html
+++ b/ui/templates/nodes.html
@@ -17,6 +17,17 @@
     <h2>Nodes <small class="text-muted">({{ .total }})</small></h2>
     <div class="d-flex gap-2 align-items-center">
       <input type="text" id="table-filter" class="form-control form-control-sm" placeholder="Filter this page..." style="width: 200px;">
+      <div class="dropdown">
+        <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+          Columns
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end" id="column-toggles">
+          <li><label class="dropdown-item"><input type="checkbox" class="form-check-input me-2" data-col="name" checked disabled> Name</label></li>
+          <li><label class="dropdown-item"><input type="checkbox" class="form-check-input me-2" data-col="ip" checked> IP Address</label></li>
+          <li><label class="dropdown-item"><input type="checkbox" class="form-check-input me-2" data-col="lastrun" checked> Last Run</label></li>
+          <li><label class="dropdown-item"><input type="checkbox" class="form-check-input me-2" data-col="environment" checked> Environment</label></li>
+        </ul>
+      </div>
       <select id="per-page-select" class="form-select form-select-sm" style="width: auto;">
         <option value="50"{{ if eq .per_page 50 }} selected{{ end }}>50</option>
         <option value="100"{{ if eq .per_page 100 }} selected{{ end }}>100</option>
@@ -51,22 +62,22 @@
   {{ end }}
 
   <div class="table-responsive">
-    <table class="table table-hover table-sm" id="nodes-table">
+    <table class="table table-hover table-sm nodes-table" id="nodes-table">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>IP Address</th>
-          <th>Last Run</th>
-          <th>Environment</th>
+          <th class="sortable resizable" data-col="name" data-sort="asc">Name <span class="sort-icon">▲</span></th>
+          <th class="sortable resizable" data-col="ip">IP Address <span class="sort-icon"></span></th>
+          <th class="sortable resizable" data-col="lastrun">Last Run <span class="sort-icon"></span></th>
+          <th class="sortable resizable" data-col="environment">Environment <span class="sort-icon"></span></th>
         </tr>
       </thead>
       <tbody>
         {{ range .nodes }}
         <tr>
-          <td><a href="{{ base_path }}/ui/nodes/{{ .Name }}">{{ .Name }}</a></td>
-          <td>{{ if .IPAddress }}{{ .IPAddress }}{{ else }}<span class="text-muted">-</span>{{ end }}</td>
-          <td class="last-run-cell" data-ohai-time="{{ .OhaiTime }}">{{ if .OhaiTime }}<span class="text-muted">-</span>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
-          <td>{{ if .Environment }}<a href="{{ base_path }}/ui/environments/{{ .Environment }}">{{ .Environment }}</a>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+          <td data-col="name"><a href="{{ base_path }}/ui/nodes/{{ .Name }}">{{ .Name }}</a></td>
+          <td data-col="ip">{{ if .IPAddress }}{{ .IPAddress }}{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+          <td data-col="lastrun" class="last-run-cell" data-ohai-time="{{ .OhaiTime }}">{{ if .OhaiTime }}<span class="text-muted">-</span>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+          <td data-col="environment">{{ if .Environment }}<a href="{{ base_path }}/ui/environments/{{ .Environment }}">{{ .Environment }}</a>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
         </tr>
         {{ end }}
       </tbody>
@@ -99,7 +110,11 @@
   {{ end }}
 
   <script type="module">
-    // Format last run times
+    const table = document.getElementById('nodes-table');
+    const tableBody = table.querySelector('tbody');
+    const rows = Array.from(tableBody.querySelectorAll('tr'));
+
+    // Format last run times and store numeric value for sorting
     document.querySelectorAll('.last-run-cell').forEach(cell => {
       const ohaiTime = parseFloat(cell.dataset.ohaiTime);
       if (ohaiTime && ohaiTime > 0) {
@@ -109,11 +124,70 @@
       }
     });
 
+    // Column visibility
+    const STORAGE_KEY = 'chefbrowser_nodes_columns';
+    const savedCols = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+
+    function applyColumnVisibility() {
+      document.querySelectorAll('#column-toggles input[data-col]').forEach(checkbox => {
+        const col = checkbox.dataset.col;
+        if (col === 'name') return;
+        const visible = savedCols[col] !== false;
+        checkbox.checked = visible;
+        table.querySelectorAll(`[data-col="${col}"]`).forEach(el => {
+          el.style.display = visible ? '' : 'none';
+        });
+      });
+    }
+    applyColumnVisibility();
+
+    document.querySelectorAll('#column-toggles input[data-col]').forEach(checkbox => {
+      checkbox.addEventListener('change', (e) => {
+        const col = e.target.dataset.col;
+        savedCols[col] = e.target.checked;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(savedCols));
+        table.querySelectorAll(`[data-col="${col}"]`).forEach(el => {
+          el.style.display = e.target.checked ? '' : 'none';
+        });
+      });
+    });
+
+    // Client-side sorting
+    const headers = table.querySelectorAll('th.sortable');
+    headers.forEach(header => {
+      header.style.cursor = 'pointer';
+      header.addEventListener('click', () => {
+        const col = header.dataset.col;
+        const currentSort = header.dataset.sort;
+        const newSort = currentSort === 'asc' ? 'desc' : 'asc';
+
+        headers.forEach(h => {
+          h.dataset.sort = '';
+          h.querySelector('.sort-icon').textContent = '';
+        });
+        header.dataset.sort = newSort;
+        header.querySelector('.sort-icon').textContent = newSort === 'asc' ? '▲' : '▼';
+
+        rows.sort((a, b) => {
+          let aVal = a.querySelector(`[data-col="${col}"]`).textContent.trim();
+          let bVal = b.querySelector(`[data-col="${col}"]`).textContent.trim();
+
+          if (col === 'lastrun') {
+            const aTime = parseFloat(a.querySelector(`[data-col="${col}"]`).dataset.ohaiTime) || 0;
+            const bTime = parseFloat(b.querySelector(`[data-col="${col}"]`).dataset.ohaiTime) || 0;
+            return newSort === 'asc' ? aTime - bTime : bTime - aTime;
+          }
+
+          const cmp = aVal.localeCompare(bVal, undefined, { numeric: true, sensitivity: 'base' });
+          return newSort === 'asc' ? cmp : -cmp;
+        });
+
+        rows.forEach(row => tableBody.appendChild(row));
+      });
+    });
+
     // Client-side table filtering
     const filterInput = document.getElementById('table-filter');
-    const tableBody = document.querySelector('#nodes-table tbody');
-    const rows = tableBody.querySelectorAll('tr');
-
     filterInput.addEventListener('input', (e) => {
       const filter = e.target.value.toLowerCase();
       rows.forEach(row => {
@@ -129,6 +203,42 @@
       url.searchParams.set('per_page', e.target.value);
       url.searchParams.set('page', '1');
       window.location.href = url.toString();
+    });
+
+    // Column resizing
+    const WIDTHS_KEY = 'chefbrowser_nodes_widths';
+    const savedWidths = JSON.parse(localStorage.getItem(WIDTHS_KEY) || '{}');
+
+    headers.forEach(header => {
+      const col = header.dataset.col;
+      if (savedWidths[col]) {
+        header.style.width = savedWidths[col];
+      }
+
+      const resizer = document.createElement('div');
+      resizer.className = 'col-resizer';
+      header.appendChild(resizer);
+
+      let startX, startWidth;
+      resizer.addEventListener('mousedown', (e) => {
+        e.stopPropagation();
+        startX = e.pageX;
+        startWidth = header.offsetWidth;
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+      });
+
+      function onMouseMove(e) {
+        const width = startWidth + (e.pageX - startX);
+        header.style.width = width + 'px';
+      }
+
+      function onMouseUp() {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        savedWidths[col] = header.style.width;
+        localStorage.setItem(WIDTHS_KEY, JSON.stringify(savedWidths));
+      }
     });
   </script>
 {{ end }}

--- a/ui/templates/partials/node/header.html
+++ b/ui/templates/partials/node/header.html
@@ -1,4 +1,4 @@
-<div class="d-flex flex-row">
+<div class="d-flex flex-row align-items-center flex-wrap gap-2">
   <h2 class="node-headline mb-0">{{ .node.Name }}
       {{ if index .node.AutomaticAttributes "ipaddress" }}
         <small class="text-muted">({{ index .node.AutomaticAttributes "ipaddress" }})</small>
@@ -10,8 +10,21 @@
   </a>
   <ul id="custom-links" class="dropdown-menu"></ul>
   {{ end }}
-  <div class="node-highlights">
-    <!-- badges will go here eventually (#74) -->
+  <div class="node-badges d-flex gap-1 ms-2">
+    {{ if index .node.AutomaticAttributes "platform" }}
+      <span class="badge text-bg-secondary">{{ index .node.AutomaticAttributes "platform" }}{{ if index .node.AutomaticAttributes "platform_version" }} {{ index .node.AutomaticAttributes "platform_version" }}{{ end }}</span>
+    {{ end }}
+    {{ if index .node.AutomaticAttributes "kernel" }}{{ if index .node.AutomaticAttributes "kernel" "machine" }}
+      <span class="badge text-bg-secondary">{{ index .node.AutomaticAttributes "kernel" "machine" }}</span>
+    {{ end }}{{ end }}
+    {{ if index .node.AutomaticAttributes "chef_packages" }}
+      {{ if index .node.AutomaticAttributes "chef_packages" "cinc" }}{{ if index .node.AutomaticAttributes "chef_packages" "cinc" "version" }}
+        <span class="badge text-bg-info">cinc {{ index .node.AutomaticAttributes "chef_packages" "cinc" "version" }}</span>
+      {{ end }}{{ end }}
+      {{ if index .node.AutomaticAttributes "chef_packages" "chef" }}{{ if index .node.AutomaticAttributes "chef_packages" "chef" "version" }}
+        <span class="badge text-bg-warning">chef {{ index .node.AutomaticAttributes "chef_packages" "chef" "version" }}</span>
+      {{ end }}{{ end }}
+    {{ end }}
   </div>
 </div>
 
@@ -42,16 +55,6 @@
     </li>
   </ul>
   <div class="node-highlights text-end">
-    <!-- TODO: write template function to check nested values because this is ridiculous -->
-      {{ if index .node.AutomaticAttributes "lsb" }}
-          {{ if index .node.AutomaticAttributes "lsb" "description" }}
-            <div><span class="text-muted">OS:</span> <span>{{ index .node.AutomaticAttributes "lsb" "description" }}</span></div>
-          {{ end }}{{ end }}
-      {{ if index .node.AutomaticAttributes "chef_packages"}}
-          {{ if index .node.AutomaticAttributes "chef_packages" "chef" }}
-              {{ if index .node.AutomaticAttributes "chef_packages" "chef" "version" }}
-                <div><span class="text-muted">Chef version:</span> <span>{{ index .node.AutomaticAttributes "chef_packages" "chef" "version" }}</span></div>
-              {{ end }}{{ end }}{{ end }}
       {{ if index .node.AutomaticAttributes "ohai_time" }}
         <div><span class="text-muted">Last chef run:</span> <span id="last-run-timestamp"></span></div>
         <script type="module">

--- a/ui/templates/partials/node/header.html
+++ b/ui/templates/partials/node/header.html
@@ -11,6 +11,9 @@
   <ul id="custom-links" class="dropdown-menu"></ul>
   {{ end }}
   <div class="node-badges d-flex gap-1 ms-2">
+    {{ if not .node.PolicyName }}{{ if .node.Environment }}
+      <a href="{{ base_path }}/ui/environments/{{ .node.Environment }}" class="badge text-bg-primary text-decoration-none">{{ .node.Environment }}</a>
+    {{ end }}{{ end }}
     {{ if index .node.AutomaticAttributes "platform" }}
       <span class="badge text-bg-secondary">{{ index .node.AutomaticAttributes "platform" }}{{ if index .node.AutomaticAttributes "platform_version" }} {{ index .node.AutomaticAttributes "platform_version" }}{{ end }}</span>
     {{ end }}
@@ -39,11 +42,6 @@
         <li>
           <strong>Policy Group:</strong>
           <a href="{{ base_path }}/ui/policy-groups/{{ .node.PolicyGroup }}">{{ .node.PolicyGroup }}</a>
-        </li>
-      {{ else }}
-        <li>
-          <strong>Environment:</strong>
-          <a href="{{ base_path }}/ui/environments/{{ .node.Environment}}">{{ .node.Environment}}</a>
         </li>
       {{ end }}
     <li><strong>Run List:</strong>

--- a/ui/templates/policy-groups.html
+++ b/ui/templates/policy-groups.html
@@ -1,4 +1,18 @@
 {{ define "content"}}
-  <h2>Policy Groups</h2>
-  {{ . }}
+  {{ if not .policy_groups }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M5.338 1.59a61 61 0 0 0-2.837.856.48.48 0 0 0-.328.39c-.554 4.157.726 7.19 2.253 9.188a10.7 10.7 0 0 0 2.287 2.233c.346.244.652.42.893.533q.18.085.293.118a1 1 0 0 0 .101.025 1 1 0 0 0 .1-.025q.114-.034.294-.118c.24-.113.547-.29.893-.533a10.7 10.7 0 0 0 2.287-2.233c1.527-1.997 2.807-5.031 2.253-9.188a.48.48 0 0 0-.328-.39c-.651-.213-1.75-.56-2.837-.855C9.552 1.29 8.531 1.067 8 1.067c-.53 0-1.552.223-2.662.524zM5.072.56C6.157.265 7.31 0 8 0s1.843.265 2.928.56c1.11.3 2.229.655 2.887.87a1.54 1.54 0 0 1 1.044 1.262c.596 4.477-.787 7.795-2.465 9.99a11.8 11.8 0 0 1-2.517 2.453 7 7 0 0 1-1.048.625c-.28.132-.581.24-.829.24s-.548-.108-.829-.24a7 7 0 0 1-1.048-.625 11.8 11.8 0 0 1-2.517-2.453C1.928 10.487.545 7.169 1.141 2.692A1.54 1.54 0 0 1 2.185 1.43 63 63 0 0 1 5.072.56"/>
+    </svg>
+    <h4 class="text-muted">No policy groups found</h4>
+    <p class="text-muted">There are no policy groups on this Chef server.</p>
+  </div>
+  {{ else }}
+  <h2>Policy Groups <small class="text-muted">({{ len .policy_groups }})</small></h2>
+  <ul id="policy-group-list" class="list-unstyled">
+      {{ range $name, $data := .policy_groups}}
+        <li><a href="{{ base_path }}/ui/policy-groups/{{$name}}">{{$name}}</a></li>
+      {{ end }}
+  </ul>
+  {{ end }}
 {{ end }}

--- a/ui/templates/roles.html
+++ b/ui/templates/roles.html
@@ -1,8 +1,18 @@
 {{ define "content"}}
+  {{ if not .roles }}
+  <div class="text-center py-5">
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="text-muted mb-3" viewBox="0 0 16 16">
+      <path d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/>
+    </svg>
+    <h4 class="text-muted">No roles found</h4>
+    <p class="text-muted">There are no roles on this Chef server.</p>
+  </div>
+  {{ else }}
   <h2>Roles <small class="text-muted">({{ len .roles }})</small></h2>
   <ul id="role-list" class="list-unstyled">
       {{ range .roles }}
         <li><a href="{{ base_path }}/ui/roles/{{.}}">{{.}}</a></li>
       {{ end }}
   </ul>
+  {{ end }}
 {{ end }}

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -13,6 +13,14 @@ export default defineConfig({
       '~bootswatch': path.resolve(__dirname, 'node_modules/bootswatch'),
     }
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin', 'color-functions'],
+        quietDeps: true,
+      },
+    },
+  },
   build: {
     // generate manifest.json in outDir
     manifest: true,


### PR DESCRIPTION
 ## What's in this PR

- Mock data for development - Run with --use-mock-data to get 1500 fake nodes, roles, cookbooks, etc. without needing a real Chef server.
- CLI flags for everything
- node list improvements - Paginated table view with IP, environment, and last check-in time. 
- small UI fixes - Empty states on all list pages, dark mode toggle in navbar, silenced Sass warnings.
- added escaping to fuzzy search string 

### Testing
- make test ✓
- make build ✓
- some smoke test locally ✓

Fixes #491
Fixes #32
Fixes #36 
Fixes #91

Preview:

<img width="1385" height="1307" alt="image" src="https://github.com/user-attachments/assets/cd204bef-ae29-4cbf-b288-657c8e0879ab" />
<img width="1391" height="1246" alt="image" src="https://github.com/user-attachments/assets/fd873a6b-3924-46ae-9e89-426a236d83d2" />
<img width="1360" height="447" alt="image" src="https://github.com/user-attachments/assets/667a3919-6fab-4a5e-bf6b-789856056d01" />

